### PR TITLE
Using sklearn models as OT functions

### DIFF
--- a/otsklearn/__init__.py
+++ b/otsklearn/__init__.py
@@ -6,6 +6,7 @@
 """
 
 from .otsklearn import *
+from .sklearn_function import *
 
 __version__ = "0.1"
 

--- a/otsklearn/sklearn_function.py
+++ b/otsklearn/sklearn_function.py
@@ -1,0 +1,78 @@
+"""
+    Scikit learn metamodels algorithm
+    =================================
+    Interpret sklearn algorithms as openturns Function
+"""
+import openturns as ot
+import numpy as np
+from sklearn.utils.validation import check_is_fitted
+
+class SklearnPyFunction(ot.OpenTURNSPythonFunction):
+    """
+    Define a OpenTURNS Function using Machine learning algorithms from scikit.
+
+    Parameters
+    ----------
+    algo : a scikit algo
+        Algo for response surface, already trained/validated
+    in_dim : int
+        Input dimension
+    out_dim: int
+        Output dimension
+
+    Examples
+    --------
+    import openturns as ot
+    from sklearn.ensemble import RandomForestRegressor
+    size = 10
+    model = ot.SymbolicFunction("x", "(1.0 + sign(x)) * cos(x) - (sign(x) - 1) * sin(2*x)")
+    dataX = ot.Uniform().getSample(size)
+    dataY = model(dataX)
+    algo = RandomForestRegressor()
+    algo.fit(dataX, dataY)
+    py_func = SklearnPyFunction(algo, 1, 1)
+    """
+    def __init__(self, algo, in_dim, out_dim):
+        super(SklearnPyFunction, self).__init__(in_dim, out_dim)
+        check_is_fitted(algo)
+        self.algo = algo
+
+    def _exec(self, x):
+        X = np.reshape(x, (1, -1))
+        return self.algo.predict(X).ravel()
+
+    def _exec_sample(self, x):
+        X = np.array(x)
+        size = len(X)
+        return self.algo.predict(X).reshape(size, self.getOutputDimension())
+
+
+class SklearnFunction(ot.Function):
+    """
+    Define an OpenTURNS Function using sklearn algorithms
+
+    Parameters
+    ----------
+    algo : a scikit algo
+        Algo for response surface, already trained/validated
+    in_dim : int
+        Input dimension
+    out_dim: int
+        Output dimension
+
+    Examples
+    --------
+    import openturns as ot
+    from sklearn.ensemble import RandomForestRegressor
+    size = 10
+    model = ot.SymbolicFunction("x", "(1.0 + sign(x)) * cos(x) - (sign(x) - 1) * sin(2*x)")
+    dataX = ot.Uniform().getSample(size)
+    dataY = model(dataX)
+    algo = RandomForestRegressor()
+    algo.fit(dataX, dataY)
+    f = SklearnFunction(algo, 1, 1)
+    """
+    def __new__(self, algo, in_dim, out_dim):
+        python_function = SklearnPyFunction(algo, in_dim, out_dim)
+        return ot.Function(python_function)
+

--- a/test/test_sklearn_func.py
+++ b/test/test_sklearn_func.py
@@ -1,0 +1,27 @@
+import otsklearn
+from sklearn import datasets
+import openturns as ot
+import numpy as np
+import pytest
+import numpy.testing as npt
+from sklearn.linear_model import LinearRegression
+
+@pytest.fixture(scope="session")
+def data():
+    """Load diabetes dataset."""
+    dataset = datasets.load_diabetes()
+    X = dataset.data
+    y = dataset.target.reshape(-1,1)
+    dim = X.shape[1]
+    return X, y, dim
+
+
+def test_linear(data):
+    X, y, dim = data
+
+    estimator = LinearRegression()
+    estimator.fit(X, y)
+    f = otsklearn.SklearnFunction(estimator, dim, 1)
+    X8 = X[8, :]
+    assert np.ravel(f(X8)) == pytest.approx(158.8, abs=0.1)
+


### PR DESCRIPTION
The purpose is to allow using `sklearn` algorithms as `openturns` functions.

We can for example use `RandomForstRegression` as a `PythonFunction`